### PR TITLE
Indent after a line with trailing =

### DIFF
--- a/indent/erlang.vim
+++ b/indent/erlang.vim
@@ -1404,8 +1404,11 @@ function! ErlangIndent()
       call s:Log('First non-empty line of the file -> return 0.')
       return 0
     else
-      let ml = matchlist(getline(lnum), '=\(s*\)')
-      " If the previous line ended with a '=', then indent by one sw
+      let ml = matchlist(getline(lnum), '^\(s*\)[^%]*=\(s*\)$')
+      " If the previous line:
+      "     1. is not commented and
+      "     2. ends with a '=' sign (possibly with trailing space)
+      " then indent by one shiftwidth.
       " Example:
       " ThisIsALongVariable =
       "     case X of

--- a/indent/erlang.vim
+++ b/indent/erlang.vim
@@ -1415,7 +1415,6 @@ function! ErlangIndent()
       if !empty(ml)
         let new_col = s:ErlangCalcIndent(v:lnum - 1, [])
         let new_col += &sw
-        echoerr new_col
         return new_col
       endif
     endif

--- a/indent/erlang.vim
+++ b/indent/erlang.vim
@@ -1398,6 +1398,27 @@ function! ErlangIndent()
         return new_col
       endif
     endif
+  else " else, if the previous line ended with '='
+    let lnum = prevnonblank(v:lnum - 1)
+    if lnum ==# 0
+      call s:Log('First non-empty line of the file -> return 0.')
+      return 0
+    else
+      let ml = matchlist(getline(lnum), '=\(s*\)')
+      " If the previous line ended with a '=', then indent by one sw
+      " Example:
+      " ThisIsALongVariable =
+      "     case X of
+      "         [] -> ok;
+      "         _ -> error
+      "     end,
+      if !empty(ml)
+        let new_col = s:ErlangCalcIndent(v:lnum - 1, [])
+        let new_col += &sw
+        echoerr new_col
+        return new_col
+      endif
+    endif
   endif
 
   let ml = matchlist(currline,


### PR DESCRIPTION
In OTP, indentation after `=` is handled similar to this example:

    f(X) ->
        MyVariable =
            case X of
                true -> ok;
                false -> still_ok
            end,
        MyVariable.

This PR implements indentation after a trailing `=` (with possible whitespace). When a trailing `=` is encountered, the following line is indented by one shiftwidth of the previous line.

I chose to implement this nearby the implementation of handling comments, as I guessed that this would be the proper way to do this. If the logic should be placed somewhere else instead, please let me know.
