### PR TITLE
Use 'shiftwidth()' instead of '&shiftwidth'

### DIFF
--- a/indent/erlang.vim
+++ b/indent/erlang.vim
@@ -680,7 +680,7 @@ function! s:BeginningOfClauseFound(stack, token, stored_vcol, lnum, i)
     call s:Pop(a:stack)
     if empty(a:stack)
       call s:Log('    Stack is ["when"], so LTI is in a guard -> return')
-      return [1, a:stored_vcol + &sw + 2]
+      return [1, a:stored_vcol + shiftwidth() + 2]
     else
       return [1, s:UnexpectedToken(a:token, a:stack)]
     endif
@@ -689,7 +689,7 @@ function! s:BeginningOfClauseFound(stack, token, stored_vcol, lnum, i)
     call s:Pop(a:stack)
     if empty(a:stack)
       call s:Log('    Stack is ["->"], so LTI is in function body -> return')
-      return [1, a:stored_vcol + &sw]
+      return [1, a:stored_vcol + shiftwidth()]
     elseif a:stack[0] ==# ';'
       call s:Pop(a:stack)
 
@@ -841,7 +841,7 @@ function! s:ErlangCalcIndent2(lnum, stack)
 
       elseif token ==# 'begin'
         let [ret, res] = s:BeginElementFound(stack, token, curr_vcol,
-                                            \stored_vcol, 'end', &sw)
+                                            \stored_vcol, 'end', shiftwidth())
         if ret | return res | endif
 
       " case EXPR of BRANCHES end
@@ -892,11 +892,11 @@ function! s:ErlangCalcIndent2(lnum, stack)
         elseif stack == ['->']
           call s:Log('    LTI is in a branch after ' .
                     \'"of/receive/after/if/catch" -> return')
-          return stored_vcol + &sw
+          return stored_vcol + shiftwidth()
         elseif stack == ['when']
           call s:Log('    LTI is in a guard after ' .
                     \'"of/receive/after/if/catch" -> return')
-          return stored_vcol + &sw
+          return stored_vcol + shiftwidth()
         else
           return s:UnexpectedToken(token, stack)
         endif
@@ -932,7 +932,7 @@ function! s:ErlangCalcIndent2(lnum, stack)
           if empty(stack)
             call s:Log('    LTI is in a condition; matching ' .
                       \'"case/if/try/receive" found')
-            let stored_vcol = curr_vcol + &sw
+            let stored_vcol = curr_vcol + shiftwidth()
           elseif stack[0] ==# 'align_to_begin_element'
             call s:Pop(stack)
             let stored_vcol = curr_vcol
@@ -941,23 +941,23 @@ function! s:ErlangCalcIndent2(lnum, stack)
                       \'"case/if/try/receive" found')
             call s:Pop(stack)
             call s:Pop(stack)
-            let stored_vcol = curr_vcol + &sw
+            let stored_vcol = curr_vcol + shiftwidth()
           elseif stack[0] ==# '->'
             call s:Log('    LTI is in a branch; matching ' .
                       \'"case/if/try/receive" found')
             call s:Pop(stack)
-            let stored_vcol = curr_vcol + 2 * &sw
+            let stored_vcol = curr_vcol + 2 * shiftwidth()
           elseif stack[0] ==# 'when'
             call s:Log('    LTI is in a guard; matching ' .
                       \'"case/if/try/receive" found')
             call s:Pop(stack)
-            let stored_vcol = curr_vcol + 2 * &sw + 2
+            let stored_vcol = curr_vcol + 2 * shiftwidth() + 2
           endif
 
         endif
 
         let [ret, res] = s:BeginElementFound(stack, token, curr_vcol,
-                                            \stored_vcol, 'end', &sw)
+                                            \stored_vcol, 'end', shiftwidth())
         if ret | return res | endif
 
       elseif token ==# 'fun'
@@ -983,7 +983,7 @@ function! s:ErlangCalcIndent2(lnum, stack)
           " stack = ['when']  =>  LTI is in a guard
           if empty(stack)
             call s:Log('    LTI is in a condition; matching "fun" found')
-            let stored_vcol = curr_vcol + &sw
+            let stored_vcol = curr_vcol + shiftwidth()
           elseif len(stack) > 1 && stack[0] ==# '->' && stack[1] ==# ';'
             call s:Log('    LTI is in a condition; matching "fun" found')
             call s:Pop(stack)
@@ -991,15 +991,15 @@ function! s:ErlangCalcIndent2(lnum, stack)
           elseif stack[0] ==# '->'
             call s:Log('    LTI is in a branch; matching "fun" found')
             call s:Pop(stack)
-            let stored_vcol = curr_vcol + 2 * &sw
+            let stored_vcol = curr_vcol + 2 * shiftwidth()
           elseif stack[0] ==# 'when'
             call s:Log('    LTI is in a guard; matching "fun" found')
             call s:Pop(stack)
-            let stored_vcol = curr_vcol + 2 * &sw + 2
+            let stored_vcol = curr_vcol + 2 * shiftwidth() + 2
           endif
 
           let [ret, res] = s:BeginElementFound(stack, token, curr_vcol,
-                                              \stored_vcol, 'end', &sw)
+                                              \stored_vcol, 'end', shiftwidth())
           if ret | return res | endif
         else
           " Pass: we have a function reference (e.g. "fun f/0")
@@ -1273,7 +1273,7 @@ function! s:ErlangCalcIndent2(lnum, stack)
             "   when A,
             "        LTI
             let [ret, res] = s:BeginElementFoundIfEmpty(stack, token, curr_vcol,
-                                                       \stored_vcol, &sw)
+                                                       \stored_vcol, shiftwidth())
             if ret | return res | endif
           else
             " Example:
@@ -1305,7 +1305,7 @@ function! s:ErlangCalcIndent2(lnum, stack)
           " If LTI is between an 'after' and the corresponding
           " 'end', then let's return
           let [ret, res] = s:BeginElementFoundIfEmpty(stack, token, curr_vcol,
-                                                     \stored_vcol, &sw)
+                                                     \stored_vcol, shiftwidth())
           if ret | return res | endif
         endif
 


### PR DESCRIPTION
Dear vim-erlang developers,

Recently, I sent a patch to vim_dev, Vim developer mailing list.
But I was transferred to send a patch to you.

----------------------------------------------------------------------------------------------------

* Remaining &shiftwidth references in indent plugins
  * https://groups.google.com/forum/#!topic/vim_dev/BcDThxEkwNA
* GitHub issue
  * https://github.com/vim/vim/issues/1493

----------------------------------------------------------------------------------------------------

shiftwidth(), introduced in Vim 7.4.694, should be used instead of
direct reference to '&shiftwidth' option value. 'set sw=0' makes
Vim behave like 'set sw={tabstop option value}' (:help shiftwidth()).

But currently this feature does not work on your indent plugins
due to the direct reference '&shiftwidth'.

And I guess you are the maintainer of the following indent plugins:
* erlang.vim

I would be glad if you merge this pull request,
And then, would you like to send the latest plugins to Bram?