### PR TITLE
Set include search options

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,58 @@ Notes:
   ```bash
   -c ':set runtimepath^=~/.vim/bundle/vim-erlang-runtime/'
   ```
+
+## Running vader tests
+
+The tests for the `include` and `define` options in `test_include_search.vader`
+are run using the [vader](https://github.com/junegunn/vader.vim) Vim plugin.
+
+A common pattern to use for test cases is to do
+
+```vim
+Given:
+  text to test
+
+Do:
+  daw
+
+Expect:
+  to text
+```
+
+The text that should be tested is placed in the `Given` block. A normal command
+is placed in the `Do` block and the expected output in the `Expect` block. The
+cursor is by default on the first column in the first line, and doing `daw`
+should therefore delete around the first word.
+
+The simplest way to run a vader test file is to open the test file in Vim and
+run `:Vader`. To run it from the command line, do `vim '+Vader!*' && echo
+Success || echo Failure`. If the environment variable `VADER_OUTPUT_FILE` is
+set, the results are written to this file.
+
+To test the code with only the wanted plugins loaded and without a vimrc, a
+similar command as for testing indentation can be run from the command line. The
+command below does the following:
+
+- Starts Vim with nocompatible set and without sourcing any vimrc.
+- Puts the current folder first in the runtimepath, such that the ftplugin,
+  indent etc. in the current folder are sourced first. Then the regular runtime
+  path is added and finally the path to where vader is installed is added (this
+  will be different depending on which plugin manager you use, the path below is
+  where vim-plug puts it).
+- Sources the vader plugin file so that the `Vader` command can be used.
+- Enables using filetype specific settings and indentation.
+- Runs all vader test files found in the current directory and then exits Vim.
+- Echoes `Success` if all test cases pass, else `Failure`.
+
+```bash
+vim -N -u NONE \
+    -c 'set runtimepath=.,$VIMRUNTIME,~/.vim/plugged/vader.vim' \
+    -c 'runtime plugin/vader.vim' \
+    -c 'filetype plugin indent on' \
+    -c 'Vader!*' \
+    && echo Success || echo Failure
+```
+
+For more details, see the [vader](https://github.com/junegunn/vader.vim)
+repository.

--- a/ftplugin/erlang.vim
+++ b/ftplugin/erlang.vim
@@ -46,6 +46,11 @@ function s:SetErlangOptions()
 
 	setlocal formatoptions+=ro
 	let &l:keywordprg = g:erlang_keywordprg
+
+        setlocal suffixesadd=.erl,.hrl
+
+        let &l:include = '^\s*-\%(include\|include_lib\)\s*("\zs\f*\ze")'
+        let &l:define  = '^\s*-\%(define\|record\|type\|opaque\)'
 endfunction
 
 function GetErlangFold(lnum)
@@ -82,7 +87,7 @@ endfunction
 call s:SetErlangOptions()
 
 let b:undo_ftplugin = "setlocal foldmethod< foldexpr< foldtext<"
-	\ . " comments< commentstring< formatoptions<"
+	\ . " comments< commentstring< formatoptions< suffixesadd< include< define<"
 
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/test_include_search.vader
+++ b/test_include_search.vader
@@ -1,0 +1,284 @@
+# Tests for include and define, which are set in ftplugin/erlang.vim
+# Include {{{1
+
+Given erlang(include):
+  -include("header.hrl").
+
+Execute:
+  let actual = split(execute('checkpath'), "---\n")[-1]
+  let expected = '"header.hrl"'
+  AssertEqual expected, actual
+
+Given erlang(include: space before -):
+     -include("header.hrl").
+
+Execute:
+  let actual = split(execute('checkpath'), "---\n")[-1]
+  let expected = '"header.hrl"'
+  AssertEqual expected, actual
+
+Given erlang(include: space before opening parenthesis):
+  -include   ("header.hrl").
+
+Execute:
+  let actual = split(execute('checkpath'), "---\n")[-1]
+  let expected = '"header.hrl"'
+  AssertEqual expected, actual
+
+# Include_lib {{{1
+
+Given erlang(include_lib):
+  -include_lib("header.hrl").
+
+Execute:
+  let actual = split(execute('checkpath'), "---\n")[-1]
+  let expected = '"header.hrl"'
+  AssertEqual expected, actual
+
+Given erlang(include_lib: space before -):
+     -include_lib("header.hrl").
+
+Execute:
+  let actual = split(execute('checkpath'), "---\n")[-1]
+  let expected = '"header.hrl"'
+  AssertEqual expected, actual
+
+Given erlang(include_lib: space before opening parenthesis):
+  -include_lib   ("header.hrl").
+
+Execute:
+  let actual = split(execute('checkpath'), "---\n")[-1]
+  let expected = '"header.hrl"'
+  AssertEqual expected, actual
+
+# Macro definition {{{1
+Given erlang(macro):
+  -define(PI, 3.14).
+  PI
+
+Do:
+  G[\<C-D>x
+
+Expect erlang:
+  -define(I, 3.14).
+  PI
+
+Given erlang((macro: space before -):
+      -define(PI, 3.14).
+  PI
+
+Do:
+  G[\<C-D>x
+
+Expect erlang:
+      -define(I, 3.14).
+  PI
+
+Given erlang(macro: space before opening parenthesis):
+  -define   (PI, 3.14).
+  PI
+
+Do:
+  G[\<C-D>x
+
+Expect erlang:
+  -define   (I, 3.14).
+  PI
+
+Given erlang(macro: definition not found):
+  -define(PIE, 3.14).
+  PI
+
+Execute:
+  $
+  AssertThrows normal [D
+
+# Record definition {{{1
+Given erlang(record):
+  -record(person, {name, phone, address}).
+  person
+
+Do:
+  G[\<C-D>x
+
+Expect erlang:
+  -record(erson, {name, phone, address}).
+  person
+
+Given erlang(record: space before -):
+     -record(person, {name, phone, address}).
+  person
+
+Do:
+  G[\<C-D>x
+
+Expect erlang:
+     -record(erson, {name, phone, address}).
+  person
+
+Given erlang(record: space before opening parenthesis):
+  -record   (person, {name, phone, address}).
+  person
+
+Do:
+  G[\<C-D>x
+
+Expect erlang:
+  -record   (erson, {name, phone, address}).
+  person
+
+Given erlang(record: definition not found):
+  -record(persona, {name, phone, address}).
+  person
+
+Execute:
+  $
+  AssertThrows normal [D
+
+# Type definition {{{1
+Given erlang(type):
+  -type my_integer() :: integer().
+  my_integer()
+
+Do:
+  G[\<C-D>x
+
+Expect erlang:
+  -type y_integer() :: integer().
+  my_integer()
+
+Given erlang(type: space before -):
+     -type my_integer() :: integer().
+  my_integer()
+
+Do:
+  G[\<C-D>x
+
+Expect erlang:
+     -type y_integer() :: integer().
+  my_integer()
+
+Given erlang(type: definition not found):
+  -type my_integera() :: integer().
+  my_integer
+
+Execute:
+  $
+  AssertThrows normal [D
+
+# Type( definition {{{1
+Given erlang(type():
+  -type(my_integer() :: integer()).
+  my_integer()
+
+Do:
+  G[\<C-D>x
+
+Expect erlang:
+  -type(y_integer() :: integer()).
+  my_integer()
+
+Given erlang(type(: space before -):
+     -type(my_integer() :: integer()).
+  my_integer()
+
+Do:
+  G[\<C-D>x
+
+Expect erlang:
+     -type(y_integer() :: integer()).
+  my_integer()
+
+Given erlang(type(: space before opening parenthesis):
+  -type   (my_integer() :: integer()).
+  my_integer()
+
+Do:
+  G[\<C-D>x
+
+Expect erlang:
+  -type   (y_integer() :: integer()).
+  my_integer()
+
+Given erlang(type(: definition not found):
+  -type(my_integera() :: integer()).
+  my_integer
+
+Execute:
+  $
+  AssertThrows normal [D
+
+# Opaque definition {{{1
+Given erlang(opaque):
+  -opaque my_integer() :: integer().
+  my_integer()
+
+Do:
+  G[\<C-D>x
+
+Expect erlang:
+  -opaque y_integer() :: integer().
+  my_integer()
+
+Given erlang(opaque: (space before -):
+     -opaque my_integer() :: integer().
+  my_integer()
+
+Do:
+  G[\<C-D>x
+
+Expect erlang:
+     -opaque y_integer() :: integer().
+  my_integer()
+
+Given erlang(opaque):
+  -opaque my_integera() :: integer().
+  my_integer()
+
+Execute:
+  $
+  AssertThrows normal [D
+
+# Opaque( definition {{{1
+Given erlang(opaque():
+  -opaque(my_integer() :: integer()).
+  my_integer()
+
+Do:
+  G[\<C-D>x
+
+Expect erlang:
+  -opaque(y_integer() :: integer()).
+  my_integer()
+
+Given erlang(opaque(: space before -):
+     -opaque(my_integer() :: integer()).
+  my_integer()
+
+Do:
+  G[\<C-D>x
+
+Expect erlang:
+     -opaque(y_integer() :: integer()).
+  my_integer()
+
+Given erlang(opaque(: space before opening parenthesis):
+  -opaque   (my_integer() :: integer()).
+  my_integer()
+
+Do:
+  G[\<C-D>x
+
+Expect erlang:
+  -opaque   (y_integer() :: integer()).
+  my_integer()
+
+Given erlang(opaque(: definition not found):
+  -opaque(my_integera() :: integer()).
+  my_integer()
+
+Execute:
+  $
+  AssertThrows normal [D
+
+# vim:foldmethod=marker


### PR DESCRIPTION
This adds the following three options in ftplugin/erlang.vim:

- `suffixesadd`
- `include`
- `define`

For `include` and `define`, I used the `let &l:...` version instead of `setlocal ...` to make it more readable. No need to escape backslashes, as mentioned in `:help 'define'`.

I also added a vader test file for testing the `include` and `define` values.

There is a bug in this file at the moment I believe, `b:undo_ftplugin` is not created if `s:did_function_definitions = 1`, i.e. the script has been sourced once, so the update of this variable in this pull request doesn't really change anything. Same for resetting `&cpo`. But that fix should probably be part of another pull request :)