### PR TITLE
Add syntax rules for anonymousVariables and highlight =<< as a syntax error

### DIFF
--- a/syntax/erlang.vim
+++ b/syntax/erlang.vim
@@ -62,6 +62,7 @@ syn match erlangModifier           '\$\%([^\\]\|\\\%(\o\{1,3}\|x\x\x\|x{\x\+}\|\
 
 " Operators, separators
 syn match erlangOperator   '==\|=:=\|/=\|=/=\|<\|=<\|>\|>=\|=>\|:=\|++\|--\|=\|!\|<-\|+\|-\|\*\|\/'
+syn match erlangEqualsBinary '=<<'
 syn keyword erlangOperator div rem or xor bor bxor bsl bsr and band not bnot andalso orelse
 syn match erlangBracket    '{\|}\|\[\|]\||\|||'
 syn match erlangPipe       '|'
@@ -77,6 +78,7 @@ syn match erlangGlobalFuncRef  '\<\%(\a[[:alnum:]_@]*\%(\s\|\n\|%.*\n\)*\.\%(\s\
 
 " Variables, macros, records, maps
 syn match erlangVariable '\<[A-Z_][[:alnum:]_@]*'
+syn match erlangAnonymousVariable '_\<[A-Z_][[:alnum:]_@]*'
 syn match erlangMacro    '??\=[[:alnum:]_@]\+'
 syn match erlangMacro    '\%(-define(\)\@<=[[:alnum:]_@]\+'
 syn region erlangQuotedMacro         start=/??\=\s*'/ end=/'/ contains=erlangQuotedAtomModifier
@@ -174,6 +176,7 @@ hi def link erlangModifier Special
 
 " Operators, separators
 hi def link erlangOperator Operator
+hi def link erlangEqualsBinary ErrorMsg
 hi def link erlangRightArrow Operator
 if s:old_style
 hi def link erlangBracket Normal
@@ -191,6 +194,7 @@ hi def link erlangLocalFuncRef Normal
 hi def link erlangGlobalFuncCall Function
 hi def link erlangGlobalFuncRef Function
 hi def link erlangVariable Normal
+hi def link erlangAnonymousVariable erlangVariable
 hi def link erlangMacro Normal
 hi def link erlangQuotedMacro Normal
 hi def link erlangRecord Normal
@@ -203,6 +207,7 @@ hi def link erlangLocalFuncRef Normal
 hi def link erlangGlobalFuncCall Normal
 hi def link erlangGlobalFuncRef Normal
 hi def link erlangVariable Identifier
+hi def link erlangAnonymousVariable erlangVariable
 hi def link erlangMacro Macro
 hi def link erlangQuotedMacro Macro
 hi def link erlangRecord Structure


### PR DESCRIPTION
* Add `erlangAnonymousVariable` class

* highlight the `=<<` part of something like `Var=<<"binary">>` (since
  that is never valid as '=<' is already an operator.