### PR TITLE
Add support for matchit plugin

### DIFF
--- a/ftplugin/erlang.vim
+++ b/ftplugin/erlang.vim
@@ -5,7 +5,8 @@
 " Contributors: Ricardo Catalinas Jiménez <jimenezrick@gmail.com>
 "               Eduardo Lopez (http://github.com/tapichu)
 "               Arvid Bjurklint (http://github.com/slarwise)
-" Last Update:  2021-Nov-22
+"               Paweł Zacharek (http://github.com/subc2)
+" Last Update:  2022-Sep-28
 " License:      Vim license
 " URL:          https://github.com/vim-erlang/vim-erlang-runtime
 
@@ -57,7 +58,7 @@ setlocal suffixesadd=.erl,.hrl
 let &l:include = '^\s*-\%(include\|include_lib\)\s*("\zs\f*\ze")'
 let &l:define  = '^\s*-\%(define\|record\|type\|opaque\)'
 
-let s:erlang_fun_begin = '^\a\w*(.*$'
+let s:erlang_fun_begin = '^\l[A-Za-z0-9_@]*(.*$'
 let s:erlang_fun_end   = '^[^%]*\.\s*\(%.*\)\?$'
 
 if !exists('*GetErlangFold')
@@ -98,6 +99,23 @@ endif
 let b:undo_ftplugin = "setlocal keywordprg< foldmethod< foldexpr< foldtext<"
       \ . " comments< commentstring< formatoptions< suffixesadd< include<"
       \ . " define<"
+
+" The following lines enable the macros/matchit.vim plugin for
+" extended matching with the % key.
+if exists("loaded_matchit")
+  let s:sw = &sw
+  if exists('*shiftwidth')
+    let s:sw = shiftwidth()
+  endif
+
+  let b:match_words =
+    \ '\<\%(begin\|case\|fun\|if\|maybe\|receive\|try\)\>' .
+    \ ':\<\%(after\|catch\|else\|of\)\>' .
+    \ ':\<end\>,' .
+    \ '^\l[A-Za-z0-9_@]*' .
+    \ ':^\%(\%(\t\| \{' . s:sw . '}\)\%([^\t\ %][^%]*\)\?\)\?;\s*\%(%.*\)\?$\|\.[\t\ %]\|\.$'
+  let b:match_skip = 's:comment\|string\|erlangmodifier\|erlangquotedatom'
+endif
 
 let &cpo = s:cpo_save
 unlet s:cpo_save


### PR DESCRIPTION
Added support for using matchit (`%` and related commands) in Erlang source files. Cycling through `begin`, `case`, `maybe`, etc. blocks works ok, as well as for function clauses ending in `.`. Function clauses ending in `;` depend on the indentation (not ideal) and will not work correctly if there is a `%` sign embedded in a string or an atom in the same line. Ideally a whole function declaration could be cycled through with a construct like `^\(\l[A-Za-z0-9_@]*\):^\1\>:\.[\t\ %]\|\.$`, though I could not get it to work.